### PR TITLE
Cas d'utilisation n°1 - se connecter

### DIFF
--- a/control/Controller.cs
+++ b/control/Controller.cs
@@ -1,4 +1,5 @@
 ﻿using Sleave.dal;
+using Sleave.model;
 using Sleave.view;
 using System;
 using System.Collections.Generic;
@@ -25,12 +26,10 @@ namespace Sleave.control
         {
             frmConnection = new FrmConnection(this);
             frmConnection.ShowDialog();
-
         }
 
         /// <summary>
-        /// Demande une connextion avec les données saisies
-        /// Ouverture de l'interface Gestion du Personnel si correct
+        /// Demande de connexion avec les données saisies. Ouvre l'interface "Gestion du Personnel" si correct
         /// </summary>
         /// <param name="login"></param>
         /// <param name="pwd"></param>
@@ -48,6 +47,24 @@ namespace Sleave.control
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Demande et retourne la liste des personnels à DataAccess
+        /// </summary>
+        /// <returns>Liste des personnels</returns>
+        public List<Personnel> GetPersonnel()
+        {
+            return DataAccess.GetPersonnel();
+        }
+
+        /// <summary>
+        /// Demande et retourne la liste des services à DataAccess
+        /// </summary>
+        /// <returns>Liste des services</returns>
+        public List<Dept> GetDepts()
+        {
+            return DataAccess.GetDepts();
         }
     }
 }

--- a/dal/DataAccess.cs
+++ b/dal/DataAccess.cs
@@ -1,4 +1,5 @@
 ﻿using Sleave.connection;
+using Sleave.model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,11 +20,11 @@ namespace Sleave.dal
         /// </summary>
         /// <param name="login"></param>
         /// <param name="pwd"></param>
-        /// <returns></returns>
+        /// <returns>Vrai ou Faux</returns>
         public static Boolean ControlAccess(string login, string pwd)
         {
-            string req = "select * from responsable res ";
-            req += "where res.login=@login and pwd=SHA2(@pwd, 256);";
+            string req = "SELECT * FROM responsable res ";
+            req += "WHERE res.login=@login AND pwd=SHA2(@pwd, 256);";
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters.Add("@login", login);
             parameters.Add("@pwd", pwd);
@@ -41,5 +42,48 @@ namespace Sleave.dal
             }
         }
 
+        /// <summary>
+        /// Récupère et retourne les personnels de la base de données
+        /// </summary>
+        /// <returns>Liste des personnels</returns>
+        public static List<Personnel> GetPersonnel()
+        {
+            List<Personnel> personnel = new List<Personnel>();
+            string req = "SELECT p.idpersonnel AS idPersonnel, s.idservice AS idDept, s.nom AS dept, p.nom AS lastName, p.prenom AS firstName, p.tel AS phone, p.mail AS mail ";
+            req += "FROM personnel p ";
+            req += "JOIN service AS s ON (p.idservice = s.idservice) ";
+            req += "ORDER BY p.idpersonnel ";
+            ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
+            curs.ReqSelect(req, null);
+            while (curs.Read())
+            {
+                Personnel pers = new Personnel((int)curs.Field("idPersonnel"), (string)curs.Field("lastName"), (string)curs.Field("firstName"), (string)curs.Field("phone"), (string)curs.Field("mail"), (int)curs.Field("idDept"), (string)curs.Field("dept"));
+                personnel.Add(pers);
+            }
+            curs.Close();
+            return personnel;
+        }
+
+        /// <summary>
+        /// Récupère et retourne les services de la base de données
+        /// </summary>
+        /// <returns>Liste des services</returns>
+        public static List<Dept> GetDepts()
+        {
+            List<Dept> depts = new List<Dept>();
+            string req = "SELECT idservice AS idDept, nom AS dept ";
+            req += "FROM `service` ";
+            req += "WHERE 1 ";
+            req += "ORDER BY dept ";
+            ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
+            curs.ReqSelect(req, null);
+            while (curs.Read())
+            {
+                Dept dept = new Dept((int)curs.Field("idDept"), (string)curs.Field("dept"));
+                depts.Add(dept);
+            }
+            curs.Close();
+            return depts;
+        }
     }
 }

--- a/view/FrmConnection.Designer.cs
+++ b/view/FrmConnection.Designer.cs
@@ -75,6 +75,7 @@ namespace Sleave.view
             // 
             this.txtPwd.Location = new System.Drawing.Point(95, 54);
             this.txtPwd.Name = "txtPwd";
+            this.txtPwd.PasswordChar = '*';
             this.txtPwd.Size = new System.Drawing.Size(100, 20);
             this.txtPwd.TabIndex = 2;
             // 

--- a/view/FrmPersonnel.Designer.cs
+++ b/view/FrmPersonnel.Designer.cs
@@ -29,10 +29,10 @@ namespace Sleave.view
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dgvPersonnel = new System.Windows.Forms.DataGridView();
             this.txtLastname = new System.Windows.Forms.TextBox();
             this.txtMail = new System.Windows.Forms.TextBox();
@@ -54,46 +54,52 @@ namespace Sleave.view
             // 
             this.dgvPersonnel.AllowUserToAddRows = false;
             this.dgvPersonnel.AllowUserToDeleteRows = false;
-            dataGridViewCellStyle1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(200)))), ((int)(((byte)(200)))), ((int)(((byte)(200)))));
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
-            this.dgvPersonnel.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
+            this.dgvPersonnel.AllowUserToResizeColumns = false;
+            this.dgvPersonnel.AllowUserToResizeRows = false;
+            dataGridViewCellStyle5.BackColor = System.Drawing.Color.WhiteSmoke;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.Black;
+            this.dgvPersonnel.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle5;
             this.dgvPersonnel.BackgroundColor = System.Drawing.SystemColors.Control;
+            this.dgvPersonnel.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dgvPersonnel.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(200)))), ((int)(((byte)(200)))), ((int)(((byte)(200)))));
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvPersonnel.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvPersonnel.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle6;
             this.dgvPersonnel.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(200)))), ((int)(((byte)(200)))), ((int)(((byte)(200)))));
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvPersonnel.DefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle7.BackColor = System.Drawing.Color.LightGray;
+            dataGridViewCellStyle7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvPersonnel.DefaultCellStyle = dataGridViewCellStyle7;
             this.dgvPersonnel.EnableHeadersVisualStyles = false;
+            this.dgvPersonnel.GridColor = System.Drawing.SystemColors.WindowFrame;
             this.dgvPersonnel.Location = new System.Drawing.Point(13, 13);
             this.dgvPersonnel.MultiSelect = false;
             this.dgvPersonnel.Name = "dgvPersonnel";
             this.dgvPersonnel.ReadOnly = true;
             this.dgvPersonnel.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvPersonnel.RowHeadersDefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle8.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle8.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvPersonnel.RowHeadersDefaultCellStyle = dataGridViewCellStyle8;
+            this.dgvPersonnel.RowHeadersVisible = false;
+            this.dgvPersonnel.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.dgvPersonnel.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvPersonnel.Size = new System.Drawing.Size(775, 235);
+            this.dgvPersonnel.Size = new System.Drawing.Size(773, 221);
             this.dgvPersonnel.TabIndex = 1;
             // 
             // txtLastname
@@ -180,14 +186,14 @@ namespace Sleave.view
             // cboAction
             // 
             this.cboAction.FormattingEnabled = true;
-            this.cboAction.Location = new System.Drawing.Point(468, 303);
+            this.cboAction.Location = new System.Drawing.Point(478, 272);
             this.cboAction.Name = "cboAction";
             this.cboAction.Size = new System.Drawing.Size(175, 21);
             this.cboAction.TabIndex = 12;
             // 
             // btnValid
             // 
-            this.btnValid.Location = new System.Drawing.Point(468, 336);
+            this.btnValid.Location = new System.Drawing.Point(478, 305);
             this.btnValid.Name = "btnValid";
             this.btnValid.Size = new System.Drawing.Size(75, 23);
             this.btnValid.TabIndex = 13;
@@ -196,7 +202,7 @@ namespace Sleave.view
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(568, 336);
+            this.btnCancel.Location = new System.Drawing.Point(578, 305);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 14;
@@ -229,6 +235,7 @@ namespace Sleave.view
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Gestion du personnel";
+            this.Load += new System.EventHandler(this.FrmPersonnel_Load);
             ((System.ComponentModel.ISupportInitialize)(this.dgvPersonnel)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/view/FrmPersonnel.cs
+++ b/view/FrmPersonnel.cs
@@ -1,4 +1,5 @@
 ﻿using Sleave.control;
+using Sleave.model;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -21,7 +22,16 @@ namespace Sleave.view
         /// </summary>
         Controller controller;
 
-        
+        /// <summary>
+        /// Objet source gérant la liste des personnels
+        /// </summary>
+        BindingSource bdgPersonnel = new BindingSource();
+
+        /// <summary>
+        /// Objet source gérant la liste des services
+        /// </summary>
+        BindingSource bdgDepts = new BindingSource();
+
 
         /// <summary>
         /// Initialise les éléments de l'interface du personnel
@@ -30,6 +40,96 @@ namespace Sleave.view
         {
             this.controller = controller;
             InitializeComponent();
+            BindDGVPersonnel();
+            BindDGVDepts();
+            BindActions();
+            DrawDGVPersonnel();
+            TogglePersFields();
+            ToggleButtons();
+        }
+
+        /// <summary>
+        /// Initialise la grille de données du personnel
+        /// </summary>
+        private void BindDGVPersonnel()
+        {
+            List<Personnel> personnel = controller.GetPersonnel();
+            bdgPersonnel.DataSource = personnel;
+            dgvPersonnel.DataSource = bdgPersonnel;
+        }
+
+        /// <summary>
+        /// Initialise la grille de données des services
+        /// </summary>
+        private void BindDGVDepts()
+        {
+            List<Dept> depts = controller.GetDepts();
+            bdgDepts.DataSource = depts;
+            cboDept.DataSource = bdgDepts;
+            cboDept.SelectedIndex = -1;
+            cboDept.Text = "";
+        }
+
+        /// <summary>
+        /// Initialise les commandes possibles dans l'interface
+        /// </summary>
+        private void BindActions()
+        {
+            cboAction.Items.Clear();
+            cboAction.Text = "Gérer les personnels";
+            cboAction.Items.Add("Ajouter");
+            cboAction.Items.Add("Supprimer");
+            cboAction.Items.Add("Modifier");
+            cboAction.Items.Add("Afficher les absences");
+        }
+
+        /// <summary>
+        /// Redessine la grille de données
+        /// </summary>
+        private void DrawDGVPersonnel()
+        {
+            dgvPersonnel.Columns["GetIdPersonnel"].HeaderText = "ID";
+            dgvPersonnel.Columns["GetLastName"].HeaderText = "Nom";
+            dgvPersonnel.Columns["GetFirstName"].HeaderText = "Prénom";
+            dgvPersonnel.Columns["GetPhone"].HeaderText = "Téléphone";
+            dgvPersonnel.Columns["GetMail"].HeaderText = "Adresse Email";
+            dgvPersonnel.Columns["GetIdDept"].Visible = false;
+            dgvPersonnel.Columns["GetDept"].HeaderText = "Service";
+            dgvPersonnel.Columns["GetDept"].DisplayIndex = 1;
+            dgvPersonnel.Columns["GetIdPersonnel"].Width = 50;
+            dgvPersonnel.Columns["GetLastName"].Width = 125;
+            dgvPersonnel.Columns["GetFirstName"].Width = 125;
+            dgvPersonnel.Columns["GetPhone"].Width = 125;
+            dgvPersonnel.Columns["GetMail"].Width = 175;
+            dgvPersonnel.Columns["GetDept"].Width = 150;
+            if (dgvPersonnel.RowCount < 10)
+            {
+                dgvPersonnel.Width = dgvPersonnel.Width - 17;
+                Width = Width - 17;
+            }
+        }
+
+        /// <summary>
+        /// Active ou désactive le champs d'information du personnel
+        /// </summary>
+        private void TogglePersFields()
+        {
+            txtLastname.Enabled = !txtLastname.Enabled;
+            txtFirstName.Enabled = !txtFirstName.Enabled;
+            txtPhone.Enabled = !txtPhone.Enabled;
+            txtMail.Enabled = !txtMail.Enabled;
+            cboDept.Enabled = !cboDept.Enabled;
+        }
+
+        private void ToggleButtons()
+        {
+            btnCancel.Enabled = !btnCancel.Enabled;
+            btnValid.Enabled = !btnValid.Enabled;
+        }
+
+        private void FrmPersonnel_Load(object sender, EventArgs e)
+        {
+
         }
     }
 }


### PR DESCRIPTION
Deuxième et dernière partie du cas d'utilisation n° 1
Une fois l'interface de gestion du personnel affichée;
- Les personnels sont liés et affichés dans la grille de données et la première ligne est selectionnée
- Les services sont liés mais ne sont pas encore affichés dans la liste déroulante
- Les actions sont liés dans la liste déroulante et le texte "Gérer le personnel" est affiché
- Les champs d'informations/ de saisies sont désactivés
- Les bouton sont désactivés
- L'utilisateur ne peut que choisir un personnel dans la grille et/ ou choisir une action dans la liste déroulante d'actions

Changements:
- La grille de donnée est redessinéee lors de son chargement
- Les champs d'action ont été déplacé
- Le champ mot de passe de l'interface de connextion n'affiche plus que des étoiles