### PR TITLE
Cas d'utilisation n° 3 - Supprimer un personnel

### DIFF
--- a/view/FrmPersonnel.cs
+++ b/view/FrmPersonnel.cs
@@ -128,11 +128,13 @@ namespace Sleave.view
                 // Supprimer
                 case 1:
                     Personnel persDel = (Personnel)bdgPersonnel.List[bdgPersonnel.Position];
-                    controller.DeleteAllAbsences(persDel.GetIdPersonnel);
-                    controller.DeletePersonnel(persDel);
-                    ResetForm();
-                    BindDGVPersonnel();
-                    bdgPersonnel.MoveFirst();
+                    if (ConfirmChange(persDel, "Supprimer le personnel n° ", "Supprimer")){
+                        controller.DeleteAllAbsences(persDel.GetIdPersonnel);
+                        controller.DeletePersonnel(persDel);
+                        ResetForm();
+                        BindDGVPersonnel();
+                        bdgPersonnel.MoveFirst();
+                    }
                     break;
                 // Modifier
                 case 2:
@@ -286,9 +288,32 @@ namespace Sleave.view
         {
             if (dgvPersonnel.RowCount < 0)
             {
+                MessageBox.Show("Aucun personnel n'est selectionné.");
+                ToggleSelection();
+                ToggleButtons();
+                cboAction.SelectedIndex = -1;
+                cboAction.Text = "Gérer le personnel";
                 return false;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Demande la confirmation de pousuivre l'action 
+        /// </summary>
+        /// <param name="pers"></param>
+        /// <param name="message"></param>
+        /// <param name="title"></param>
+        /// <returns></returns>
+        private bool ConfirmChange(Personnel pers, string message, string title)
+        {
+            if (MessageBox.Show(message + pers.GetIdPersonnel + " : " + pers.GetFirstName + " " + pers.GetLastName + " ?", title, MessageBoxButtons.YesNo) == DialogResult.Yes)
+            {
+                return true;
+            }
+            return false;
+
+
         }
     }
 }


### PR DESCRIPTION
Oublis lors de la programmation précédente.

Un personnel doit être selectionné:
- Si aucun personnel n'est pas selectionné (la liste est alors vide),  l'utlisateur est alerté. L'action est annulée.

L'utilisateur doit confirmer la suppression du personnel:
- Si la suppréssion est confirmée, les absences et le personnel seront éffacés de la BDD
- Si la suppression n'est pas confirmée, le personnel reste selectionné. L'action est toujours "supprimmer". 
- L'utlisateur peut annuler l'action en cliquant sur "Annuler"

