### PR TITLE
Cas d'utilisation n° 4 - Modifier un personnel

### DIFF
--- a/control/Controller.cs
+++ b/control/Controller.cs
@@ -86,6 +86,15 @@ namespace Sleave.control
         }
 
         /// <summary>
+        /// Demande la modification d'un personnel à DataAccess
+        /// </summary>
+        /// <param name="persUp"></param>
+        public void UpdatePersonnel(Personnel persUp)
+        {
+            DataAccess.UpdatePersonnel(persUp);
+        }
+
+        /// <summary>
         /// Demande l'effacement de toutes les absences d'un personnel à DataAccess
         /// </summary>
         /// <param name="index"></param>

--- a/dal/DataAccess.cs
+++ b/dal/DataAccess.cs
@@ -120,6 +120,25 @@ namespace Sleave.dal
         }
 
         /// <summary>
+        /// Modifie le personnel dans la base de données
+        /// </summary>
+        /// <param name="persUp"></param>
+        public static void UpdatePersonnel(Personnel persUp)
+        {
+            string req = "UPDATE personnel SET idservice = @idservice, nom = @nom, prenom = @prenom, tel = @tel, mail = @mail ";
+            req += "where idpersonnel = @idpersonnel;";
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("@idpersonnel", persUp.GetIdPersonnel);
+            parameters.Add("@nom", persUp.GetLastName);
+            parameters.Add("@prenom", persUp.GetFirstName);
+            parameters.Add("@tel", persUp.GetPhone);
+            parameters.Add("@mail", persUp.GetMail);
+            parameters.Add("@idservice", persUp.GetIdDept);
+            ConnectionDataBase conn = ConnectionDataBase.GetInstance(connectionString);
+            conn.ReqNoQuery(req, parameters);
+        }
+
+        /// <summary>
         /// Efface toutes les absences d'un personnel de la base de données
         /// </summary>
         /// <param name="index"></param>

--- a/view/FrmPersonnel.cs
+++ b/view/FrmPersonnel.cs
@@ -72,6 +72,11 @@ namespace Sleave.view
                     break;
                 // Modifier
                 case 2:
+                    if (CheckDGVIndex())
+                    {
+                        TogglePersFields();
+                        GetPersFields();
+                    }
                     break;
             }
         }
@@ -120,8 +125,6 @@ namespace Sleave.view
                         Dept deptAdd = (Dept)bdgDepts.List[bdgDepts.Position];
                         Personnel persAdd = new Personnel(0, txtLastName.Text, txtFirstName.Text, txtPhone.Text, txtMail.Text, deptAdd.GetIdDept, deptAdd.GetName);
                         controller.AddPersonnel(persAdd);
-                        ResetForm();
-                        BindDGVPersonnel();
                         bdgPersonnel.MoveLast();
                     }
                     break;
@@ -131,15 +134,25 @@ namespace Sleave.view
                     if (ConfirmChange(persDel, "Supprimer le personnel n° ", "Supprimer")){
                         controller.DeleteAllAbsences(persDel.GetIdPersonnel);
                         controller.DeletePersonnel(persDel);
-                        ResetForm();
-                        BindDGVPersonnel();
                         bdgPersonnel.MoveFirst();
                     }
                     break;
                 // Modifier
                 case 2:
+                    if (CheckPersFields())
+                    {
+                        Personnel persMod = (Personnel)bdgPersonnel.List[bdgPersonnel.Position];
+                        if (ConfirmChange(persMod, "Modifier le personnel n° ", "Modifier"))
+                        {
+                            Dept deptUp = (Dept)bdgDepts.List[bdgDepts.Position];
+                            Personnel persUp = new Personnel(persMod.GetIdPersonnel, txtLastName.Text, txtFirstName.Text, txtPhone.Text, txtMail.Text, deptUp.GetIdDept, deptUp.GetName);
+                            controller.UpdatePersonnel(persUp);
+                        }
+                    }
                     break;
             }
+            ResetForm();
+            BindDGVPersonnel();
         }
 
         /// <summary>
@@ -304,7 +317,7 @@ namespace Sleave.view
         /// <param name="pers"></param>
         /// <param name="message"></param>
         /// <param name="title"></param>
-        /// <returns></returns>
+        /// <returns>Vrai ou Faux</returns>
         private bool ConfirmChange(Personnel pers, string message, string title)
         {
             if (MessageBox.Show(message + pers.GetIdPersonnel + " : " + pers.GetFirstName + " " + pers.GetLastName + " ?", title, MessageBoxButtons.YesNo) == DialogResult.Yes)


### PR DESCRIPTION
Une fois l'interface de gestion du personnel affichée, l'utlisateur selectionne un personnel dans la grille de données.
Il choisi ensuite "Modifier" dans la liste déroulante d'actions:

- La grille et la liste d'actions sont désactivées
- Les champs d'informations/ de saisies sont activés

L'utilisateur modifie le personnel et confirme l'action en cliquant "valider":
- Le personnel est actualisé dans la base de données
- L'interface est réinitialisée comme lors de sa création

L'utilisateur peut aussi annuler l'action en cliquant "Annuler":
- L'interface est réinitialisée comme lors de sa création


Changements: 
- Les méthodes de verification sont réutilisées selon les cas.
- Le code a été nettoyé grossièrement