### PR TITLE
Cas d'utilisation n° 5 - Afficher les absences (2)

### DIFF
--- a/control/Controller.cs
+++ b/control/Controller.cs
@@ -70,6 +70,7 @@ namespace Sleave.control
             frmPersonnel.Show();
         }
 
+
         /// <summary>
         /// Demande et retourne la liste des personnels à DataAccess
         /// </summary>
@@ -86,6 +87,25 @@ namespace Sleave.control
         public List<Dept> GetDepts()
         {
             return DataAccess.GetDepts();
+        }
+
+        /// <summary>
+        /// Demande et retourne la liste d'absence d'un personnel à DataAccess
+        /// </summary>
+        /// <param name="pers"></param>
+        /// <returns></returns>
+        public List<Absence> GetAbsences(Personnel pers)
+        {
+            return DataAccess.GetAbsences(pers);
+        }
+
+        /// <summary>
+        /// Demande et retourne la liste des motifs à DataAccess
+        /// </summary>
+        /// <returns></returns>
+        public List<Reason> GetReasons()
+        {
+            return DataAccess.GetReasons();
         }
 
         /// <summary>

--- a/dal/DataAccess.cs
+++ b/dal/DataAccess.cs
@@ -87,6 +87,55 @@ namespace Sleave.dal
         }
 
         /// <summary>
+        /// Récupère et retourne les absences de la base de données
+        /// </summary>
+        /// <param name="pers"></param>
+        /// <returns>Liste des absences</returns>
+        public static List<Absence> GetAbsences(Personnel pers)
+        {
+            List<Absence> absences = new List<Absence>();
+            string req = "SELECT a.idpersonnel AS idPersonnel, p.nom AS lastName, p.prenom AS firstName, a.DateDebut AS dateStart, a.dateFin AS dateEnd, m.idmotif AS idReason, m.libelle AS reason ";
+            req += "FROM absence AS a ";
+            req += "JOIN personnel AS p ON p.idpersonnel = a.idpersonnel ";
+            req += "JOIN motif AS m ON a.idmotif = m.idmotif ";
+            req += "WHERE a.idpersonnel = @idpersonnel ";
+            req += "ORDER BY dateStart desc";
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("@idpersonnel", pers.GetIdPersonnel);
+            ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
+            curs.ReqSelect(req, parameters);
+            while (curs.Read())
+            {
+                Absence absence = new Absence((int)curs.Field("idpersonnel"), (string)curs.Field("lastName"), (string)curs.Field("firstName"), (DateTime)curs.Field("dateStart"), (DateTime)curs.Field("dateEnd"), (int)curs.Field("idReason"), (string)curs.Field("reason"));
+                absences.Add(absence);
+            }
+            curs.Close();
+            return absences;
+        }
+
+        /// <summary>
+        /// Récupère et retourne les motifs de la base de données
+        /// </summary>
+        /// <returns>Liste de motifs</returns>
+        public static List<Reason> GetReasons()
+        {
+            List<Reason> reasons = new List<Reason>();
+            string req = "SELECT idmotif AS idReason, libelle AS reason";
+            req += "FROM motif ";
+            req += "WHERE 1 ";
+            req += "ORDER BY reason ";
+            ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
+            curs.ReqSelect(req, null);
+            while (curs.Read())
+            {
+                Reason reason = new Reason((int)curs.Field("idReason"), (string)curs.Field("reason"));
+                reasons.Add(reason);
+            }
+            curs.Close();
+            return reasons;
+        }
+
+        /// <summary>
         /// Ajoute un personnel à base de données
         /// </summary>
         /// <param name="pers"></param>

--- a/model/Absence.cs
+++ b/model/Absence.cs
@@ -42,7 +42,7 @@ namespace Sleave.model
         /// <summary>
         /// Getter sur la date de fin de l'absence
         /// </summary>
-        public DateTime GetDateEnd { get => dateEnd; }
+        public DateTime GetDateEnd { get => dateEnd.Date; }
 
         /// <summary>
         /// Getter sur l'identifiant du motif de l'absence
@@ -61,10 +61,10 @@ namespace Sleave.model
         /// <param name="lastName"></param>
         /// <param name="firstName"></param>
         /// <param name="dateStart"></param>
-        /// <param name="dateFin"></param>
+        /// <param name="dateEnd"></param>
         /// <param name="idReason"></param>
         /// <param name="reason"></param>
-        public Absence(int idPersonnel, string lastName, string firstName, DateTime dateStart, DateTime dateFin, int idReason, string reason)
+        public Absence(int idPersonnel, string lastName, string firstName, DateTime dateStart, DateTime dateEnd, int idReason, string reason)
         {
             this.idPersonnel = idPersonnel;
             this.lastName = lastName;

--- a/view/FrmAbsences.Designer.cs
+++ b/view/FrmAbsences.Designer.cs
@@ -29,10 +29,10 @@ namespace Sleave.view
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnValid = new System.Windows.Forms.Button();
             this.cboAction = new System.Windows.Forms.ComboBox();
@@ -41,7 +41,7 @@ namespace Sleave.view
             this.lblFirstName = new System.Windows.Forms.Label();
             this.lblLastName = new System.Windows.Forms.Label();
             this.lblEnd = new System.Windows.Forms.Label();
-            this.cboDept = new System.Windows.Forms.ComboBox();
+            this.cboReason = new System.Windows.Forms.ComboBox();
             this.txtFirstName = new System.Windows.Forms.TextBox();
             this.txtDateStart = new System.Windows.Forms.TextBox();
             this.txtDateEnd = new System.Windows.Forms.TextBox();
@@ -54,7 +54,7 @@ namespace Sleave.view
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(701, 245);
+            this.btnCancel.Location = new System.Drawing.Point(580, 236);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 27;
@@ -63,7 +63,7 @@ namespace Sleave.view
             // 
             // btnValid
             // 
-            this.btnValid.Location = new System.Drawing.Point(601, 245);
+            this.btnValid.Location = new System.Drawing.Point(480, 236);
             this.btnValid.Name = "btnValid";
             this.btnValid.Size = new System.Drawing.Size(75, 23);
             this.btnValid.TabIndex = 26;
@@ -74,7 +74,7 @@ namespace Sleave.view
             // cboAction
             // 
             this.cboAction.FormattingEnabled = true;
-            this.cboAction.Location = new System.Drawing.Point(601, 212);
+            this.cboAction.Location = new System.Drawing.Point(480, 203);
             this.cboAction.Name = "cboAction";
             this.cboAction.Size = new System.Drawing.Size(175, 21);
             this.cboAction.TabIndex = 25;
@@ -82,7 +82,7 @@ namespace Sleave.view
             // lblReason
             // 
             this.lblReason.AutoSize = true;
-            this.lblReason.Location = new System.Drawing.Point(522, 166);
+            this.lblReason.Location = new System.Drawing.Point(401, 157);
             this.lblReason.Name = "lblReason";
             this.lblReason.Size = new System.Drawing.Size(30, 13);
             this.lblReason.TabIndex = 24;
@@ -91,7 +91,7 @@ namespace Sleave.view
             // lblDateStart
             // 
             this.lblDateStart.AutoSize = true;
-            this.lblDateStart.Location = new System.Drawing.Point(522, 102);
+            this.lblDateStart.Location = new System.Drawing.Point(401, 93);
             this.lblDateStart.Name = "lblDateStart";
             this.lblDateStart.Size = new System.Drawing.Size(60, 13);
             this.lblDateStart.TabIndex = 23;
@@ -100,7 +100,7 @@ namespace Sleave.view
             // lblFirstName
             // 
             this.lblFirstName.AutoSize = true;
-            this.lblFirstName.Location = new System.Drawing.Point(522, 67);
+            this.lblFirstName.Location = new System.Drawing.Point(401, 58);
             this.lblFirstName.Name = "lblFirstName";
             this.lblFirstName.Size = new System.Drawing.Size(43, 13);
             this.lblFirstName.TabIndex = 22;
@@ -109,7 +109,7 @@ namespace Sleave.view
             // lblLastName
             // 
             this.lblLastName.AutoSize = true;
-            this.lblLastName.Location = new System.Drawing.Point(522, 35);
+            this.lblLastName.Location = new System.Drawing.Point(401, 26);
             this.lblLastName.Name = "lblLastName";
             this.lblLastName.Size = new System.Drawing.Size(29, 13);
             this.lblLastName.TabIndex = 21;
@@ -118,44 +118,48 @@ namespace Sleave.view
             // lblEnd
             // 
             this.lblEnd.AutoSize = true;
-            this.lblEnd.Location = new System.Drawing.Point(522, 134);
+            this.lblEnd.Location = new System.Drawing.Point(401, 125);
             this.lblEnd.Name = "lblEnd";
             this.lblEnd.Size = new System.Drawing.Size(44, 13);
             this.lblEnd.TabIndex = 20;
             this.lblEnd.Text = "Date fin";
             // 
-            // cboDept
+            // cboReason
             // 
-            this.cboDept.FormattingEnabled = true;
-            this.cboDept.Location = new System.Drawing.Point(601, 163);
-            this.cboDept.Name = "cboDept";
-            this.cboDept.Size = new System.Drawing.Size(175, 21);
-            this.cboDept.TabIndex = 19;
+            this.cboReason.FormattingEnabled = true;
+            this.cboReason.Location = new System.Drawing.Point(480, 154);
+            this.cboReason.Name = "cboReason";
+            this.cboReason.Size = new System.Drawing.Size(175, 21);
+            this.cboReason.TabIndex = 19;
             // 
             // txtFirstName
             // 
-            this.txtFirstName.Location = new System.Drawing.Point(601, 64);
+            this.txtFirstName.Enabled = false;
+            this.txtFirstName.Location = new System.Drawing.Point(480, 55);
             this.txtFirstName.Name = "txtFirstName";
             this.txtFirstName.Size = new System.Drawing.Size(175, 20);
             this.txtFirstName.TabIndex = 18;
             // 
             // txtDateStart
             // 
-            this.txtDateStart.Location = new System.Drawing.Point(601, 99);
+            this.txtDateStart.Enabled = false;
+            this.txtDateStart.Location = new System.Drawing.Point(480, 90);
             this.txtDateStart.Name = "txtDateStart";
             this.txtDateStart.Size = new System.Drawing.Size(175, 20);
             this.txtDateStart.TabIndex = 17;
             // 
             // txtDateEnd
             // 
-            this.txtDateEnd.Location = new System.Drawing.Point(601, 131);
+            this.txtDateEnd.Enabled = false;
+            this.txtDateEnd.Location = new System.Drawing.Point(480, 122);
             this.txtDateEnd.Name = "txtDateEnd";
             this.txtDateEnd.Size = new System.Drawing.Size(175, 20);
             this.txtDateEnd.TabIndex = 16;
             // 
             // txtLastname
             // 
-            this.txtLastname.Location = new System.Drawing.Point(601, 32);
+            this.txtLastname.Enabled = false;
+            this.txtLastname.Location = new System.Drawing.Point(480, 23);
             this.txtLastname.Name = "txtLastname";
             this.txtLastname.Size = new System.Drawing.Size(175, 20);
             this.txtLastname.TabIndex = 15;
@@ -163,7 +167,7 @@ namespace Sleave.view
             // dtpStart
             // 
             this.dtpStart.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.dtpStart.Location = new System.Drawing.Point(601, 99);
+            this.dtpStart.Location = new System.Drawing.Point(480, 90);
             this.dtpStart.Name = "dtpStart";
             this.dtpStart.Size = new System.Drawing.Size(175, 20);
             this.dtpStart.TabIndex = 29;
@@ -171,7 +175,7 @@ namespace Sleave.view
             // dtpEnd
             // 
             this.dtpEnd.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.dtpEnd.Location = new System.Drawing.Point(601, 131);
+            this.dtpEnd.Location = new System.Drawing.Point(480, 122);
             this.dtpEnd.Name = "dtpEnd";
             this.dtpEnd.Size = new System.Drawing.Size(175, 20);
             this.dtpEnd.TabIndex = 30;
@@ -182,57 +186,57 @@ namespace Sleave.view
             this.dgvAbsences.AllowUserToDeleteRows = false;
             this.dgvAbsences.AllowUserToResizeColumns = false;
             this.dgvAbsences.AllowUserToResizeRows = false;
-            dataGridViewCellStyle1.BackColor = System.Drawing.Color.WhiteSmoke;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.DarkGray;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
-            this.dgvAbsences.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle9.BackColor = System.Drawing.Color.WhiteSmoke;
+            dataGridViewCellStyle9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            dataGridViewCellStyle9.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle9.SelectionForeColor = System.Drawing.Color.Black;
+            this.dgvAbsences.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle9;
             this.dgvAbsences.BackgroundColor = System.Drawing.SystemColors.Control;
             this.dgvAbsences.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dgvAbsences.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvAbsences.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.ControlDarkDark;
+            dataGridViewCellStyle10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle10.ForeColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle10.SelectionBackColor = System.Drawing.SystemColors.ControlDarkDark;
+            dataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvAbsences.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle10;
             this.dgvAbsences.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.LightGray;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.DarkGray;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvAbsences.DefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle11.BackColor = System.Drawing.Color.LightGray;
+            dataGridViewCellStyle11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvAbsences.DefaultCellStyle = dataGridViewCellStyle11;
             this.dgvAbsences.EnableHeadersVisualStyles = false;
-            this.dgvAbsences.GridColor = System.Drawing.SystemColors.WindowFrame;
-            this.dgvAbsences.Location = new System.Drawing.Point(14, 12);
+            this.dgvAbsences.GridColor = System.Drawing.SystemColors.ScrollBar;
+            this.dgvAbsences.Location = new System.Drawing.Point(12, 12);
             this.dgvAbsences.MultiSelect = false;
             this.dgvAbsences.Name = "dgvAbsences";
             this.dgvAbsences.ReadOnly = true;
             this.dgvAbsences.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvAbsences.RowHeadersDefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle12.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvAbsences.RowHeadersDefaultCellStyle = dataGridViewCellStyle12;
             this.dgvAbsences.RowHeadersVisible = false;
             this.dgvAbsences.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.dgvAbsences.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvAbsences.Size = new System.Drawing.Size(502, 412);
-            this.dgvAbsences.TabIndex = 31;
+            this.dgvAbsences.Size = new System.Drawing.Size(376, 265);
+            this.dgvAbsences.TabIndex = 33;
             // 
             // FrmAbsences
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(674, 301);
             this.Controls.Add(this.dgvAbsences);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnValid);
@@ -242,7 +246,7 @@ namespace Sleave.view
             this.Controls.Add(this.lblFirstName);
             this.Controls.Add(this.lblLastName);
             this.Controls.Add(this.lblEnd);
-            this.Controls.Add(this.cboDept);
+            this.Controls.Add(this.cboReason);
             this.Controls.Add(this.txtFirstName);
             this.Controls.Add(this.txtDateStart);
             this.Controls.Add(this.txtDateEnd);
@@ -272,7 +276,7 @@ namespace Sleave.view
         private System.Windows.Forms.Label lblFirstName;
         private System.Windows.Forms.Label lblLastName;
         private System.Windows.Forms.Label lblEnd;
-        private System.Windows.Forms.ComboBox cboDept;
+        private System.Windows.Forms.ComboBox cboReason;
         private System.Windows.Forms.TextBox txtFirstName;
         private System.Windows.Forms.TextBox txtDateStart;
         private System.Windows.Forms.TextBox txtDateEnd;

--- a/view/FrmAbsences.cs
+++ b/view/FrmAbsences.cs
@@ -17,6 +17,15 @@ namespace Sleave.view
     /// </summary>
     public partial class FrmAbsences : Form
     {
+        /// <summary>
+        /// Constante d'unité de largeur des champs de la grille de données
+        /// </summary>
+        private const int fieldWidthUnit = 25;
+
+        /// <summary>
+        /// Constante du nombre de ligne affichée sans barre déroulante
+        /// </summary>
+        private const int maxRows = 12;
 
         /// <summary>
         /// Instance de controle
@@ -31,12 +40,12 @@ namespace Sleave.view
         /// <summary>
         /// Objet source gérant la liste des absences
         /// </summary>
-        BindingSource bdgAbsence = new BindingSource();
+        BindingSource bdgAbsences = new BindingSource();
 
         /// <summary>
         /// Objet source gérant la liste des raison
         /// </summary>
-        BindingSource bdgReason = new BindingSource();
+        BindingSource bdgReasons = new BindingSource();
 
         /// <summary>
         /// Interface appellant cette objet
@@ -52,6 +61,14 @@ namespace Sleave.view
             this.pers = persAbsence;
             this.frmPersonnel = frmPersonnel;
             InitializeComponent();
+            txtLastname.Text = persAbsence.GetLastName;
+            txtFirstName.Text = persAbsence.GetFirstName;
+            ToggleButtons();
+            DisableAbsFields();
+            BindDGVAbsences();
+            BindDGVReasons();
+            BindActions();
+            DrawDGVAbsences();
         }
 
         /// <summary>
@@ -68,5 +85,115 @@ namespace Sleave.view
         {
 
         }
+
+        /// <summary>
+        /// Redessine la grille de données
+        /// </summary>
+        private void DrawDGVAbsences()
+        {
+            dgvAbsences.Columns["GetIdPersonnel"].Visible = false;
+            dgvAbsences.Columns["GetLastName"].Visible = false;
+            dgvAbsences.Columns["GetFirstName"].Visible = false;
+            dgvAbsences.Columns["GetDateStart"].HeaderText = "Date début";
+            dgvAbsences.Columns["GetDateEnd"].HeaderText = "Date fin";
+            dgvAbsences.Columns["GetIdReason"].Visible = false;
+            dgvAbsences.Columns["GetReason"].HeaderText = "Motif";
+            dgvAbsences.Columns["GetDateStart"].Width = fieldWidthUnit * 4;
+            dgvAbsences.Columns["GetDateEnd"].Width = fieldWidthUnit * 4;
+            dgvAbsences.Columns["GetReason"].Width = fieldWidthUnit * 6;
+        }
+
+        /// <summary>
+        /// Defini la taille du champs Motifselon le nombre de ligne dans la grille de données
+        /// </summary>
+        private void ResizeDGVAbsences()
+        {
+            if (dgvAbsences.RowCount > maxRows)
+            {
+                dgvAbsences.Columns["GetReason"].Width = fieldWidthUnit * 6;
+            }
+            else
+            {
+
+                dgvAbsences.Columns["GetReason"].Width = fieldWidthUnit * 7;
+            }
+        }
+
+        /// <summary>
+        /// Initialise la grille de données du personnel
+        /// </summary>
+        private void BindDGVAbsences()
+        {
+            List<Absence> absences = controller.GetAbsences(pers);
+            bdgAbsences.DataSource = absences;
+            dgvAbsences.DataSource = bdgAbsences;
+        }
+
+        /// <summary>
+        /// Initialise la grille de données des services
+        /// </summary>
+        private void BindDGVReasons()
+        {
+            List<Reason> reasons = controller.GetReasons();
+            bdgReasons.DataSource = reasons;
+            cboReason.DataSource = bdgReasons;
+            cboReason.SelectedIndex = -1;
+            cboReason.Text = "";
+        }
+
+        /// <summary>
+        /// Initialise les commandes possibles dans l'interface
+        /// </summary>
+        private void BindActions()
+        {
+            cboAction.Items.Clear();
+            cboAction.Text = "Gérer les personnels";
+            cboAction.Items.Add("Ajouter");
+            cboAction.Items.Add("Supprimer");
+            cboAction.Items.Add("Modifier");
+            cboAction.Items.Add("Afficher les absences");
+        }
+
+        private void EnableAbsFields()
+        {
+            dtpStart.Enabled = true;
+            dtpEnd.Enabled = true;
+            cboReason.Enabled = true;
+        }
+
+        private void DisableAbsFields()
+        {
+            dtpStart.Enabled = false;
+            dtpEnd.Enabled = false;
+            cboReason.Enabled = false;
+        }
+
+        /// <summary>
+        /// Désactive les dates d'absence
+        /// </summary>
+        private void DisableDateFields()
+        {
+            dtpStart.Enabled = false;
+            dtpEnd.Enabled = false;
+        }
+
+        /// <summary>
+        /// Active ou désactive les champs de sélection
+        /// </summary>
+        private void ToggleSelection()
+        {
+            dgvAbsences.Enabled = !dgvAbsences.Enabled;
+            cboAction.Enabled = !cboAction.Enabled;
+        }
+
+        /// <summary>
+        /// Active ou désactive les boutons
+        /// </summary>
+        private void ToggleButtons()
+        {
+            btnCancel.Enabled = !btnCancel.Enabled;
+            btnValid.Enabled = !btnValid.Enabled;
+        }
+
     }
 }

--- a/view/FrmPersonnel.Designer.cs
+++ b/view/FrmPersonnel.Designer.cs
@@ -29,11 +29,10 @@ namespace Sleave.view
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.dgvPersonnel = new System.Windows.Forms.DataGridView();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
             this.txtLastName = new System.Windows.Forms.TextBox();
             this.txtMail = new System.Windows.Forms.TextBox();
             this.txtPhone = new System.Windows.Forms.TextBox();
@@ -47,85 +46,34 @@ namespace Sleave.view
             this.cboAction = new System.Windows.Forms.ComboBox();
             this.btnValid = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
+            this.dgvPersonnel = new System.Windows.Forms.DataGridView();
             ((System.ComponentModel.ISupportInitialize)(this.dgvPersonnel)).BeginInit();
             this.SuspendLayout();
             // 
-            // dgvPersonnel
-            // 
-            this.dgvPersonnel.AllowUserToAddRows = false;
-            this.dgvPersonnel.AllowUserToDeleteRows = false;
-            this.dgvPersonnel.AllowUserToResizeColumns = false;
-            this.dgvPersonnel.AllowUserToResizeRows = false;
-            dataGridViewCellStyle9.BackColor = System.Drawing.Color.WhiteSmoke;
-            dataGridViewCellStyle9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            dataGridViewCellStyle9.SelectionBackColor = System.Drawing.Color.DarkGray;
-            dataGridViewCellStyle9.SelectionForeColor = System.Drawing.Color.Black;
-            this.dgvPersonnel.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle9;
-            this.dgvPersonnel.BackgroundColor = System.Drawing.SystemColors.Control;
-            this.dgvPersonnel.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.dgvPersonnel.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle10.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle10.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvPersonnel.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle10;
-            this.dgvPersonnel.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle11.BackColor = System.Drawing.Color.LightGray;
-            dataGridViewCellStyle11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.Color.DarkGray;
-            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvPersonnel.DefaultCellStyle = dataGridViewCellStyle11;
-            this.dgvPersonnel.EnableHeadersVisualStyles = false;
-            this.dgvPersonnel.GridColor = System.Drawing.SystemColors.WindowFrame;
-            this.dgvPersonnel.Location = new System.Drawing.Point(13, 13);
-            this.dgvPersonnel.MultiSelect = false;
-            this.dgvPersonnel.Name = "dgvPersonnel";
-            this.dgvPersonnel.ReadOnly = true;
-            this.dgvPersonnel.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle12.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvPersonnel.RowHeadersDefaultCellStyle = dataGridViewCellStyle12;
-            this.dgvPersonnel.RowHeadersVisible = false;
-            this.dgvPersonnel.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.dgvPersonnel.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvPersonnel.Size = new System.Drawing.Size(773, 221);
-            this.dgvPersonnel.TabIndex = 1;
-            // 
             // txtLastName
             // 
-            this.txtLastName.Location = new System.Drawing.Point(212, 272);
+            this.txtLastName.Location = new System.Drawing.Point(212, 262);
             this.txtLastName.Name = "txtLastName";
             this.txtLastName.Size = new System.Drawing.Size(175, 20);
             this.txtLastName.TabIndex = 2;
             // 
             // txtMail
             // 
-            this.txtMail.Location = new System.Drawing.Point(212, 371);
+            this.txtMail.Location = new System.Drawing.Point(212, 361);
             this.txtMail.Name = "txtMail";
             this.txtMail.Size = new System.Drawing.Size(175, 20);
             this.txtMail.TabIndex = 3;
             // 
             // txtPhone
             // 
-            this.txtPhone.Location = new System.Drawing.Point(212, 339);
+            this.txtPhone.Location = new System.Drawing.Point(212, 329);
             this.txtPhone.Name = "txtPhone";
             this.txtPhone.Size = new System.Drawing.Size(175, 20);
             this.txtPhone.TabIndex = 4;
             // 
             // txtFirstName
             // 
-            this.txtFirstName.Location = new System.Drawing.Point(212, 304);
+            this.txtFirstName.Location = new System.Drawing.Point(212, 294);
             this.txtFirstName.Name = "txtFirstName";
             this.txtFirstName.Size = new System.Drawing.Size(175, 20);
             this.txtFirstName.TabIndex = 5;
@@ -133,7 +81,7 @@ namespace Sleave.view
             // cboDept
             // 
             this.cboDept.FormattingEnabled = true;
-            this.cboDept.Location = new System.Drawing.Point(212, 403);
+            this.cboDept.Location = new System.Drawing.Point(212, 393);
             this.cboDept.Name = "cboDept";
             this.cboDept.Size = new System.Drawing.Size(175, 21);
             this.cboDept.TabIndex = 6;
@@ -141,7 +89,7 @@ namespace Sleave.view
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(133, 374);
+            this.label1.Location = new System.Drawing.Point(133, 364);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(73, 13);
             this.label1.TabIndex = 7;
@@ -150,7 +98,7 @@ namespace Sleave.view
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(133, 275);
+            this.label2.Location = new System.Drawing.Point(133, 265);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(29, 13);
             this.label2.TabIndex = 8;
@@ -159,7 +107,7 @@ namespace Sleave.view
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(133, 307);
+            this.label3.Location = new System.Drawing.Point(133, 297);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(43, 13);
             this.label3.TabIndex = 9;
@@ -168,7 +116,7 @@ namespace Sleave.view
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(133, 342);
+            this.label4.Location = new System.Drawing.Point(133, 332);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(58, 13);
             this.label4.TabIndex = 10;
@@ -177,7 +125,7 @@ namespace Sleave.view
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(133, 406);
+            this.label5.Location = new System.Drawing.Point(133, 396);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(43, 13);
             this.label5.TabIndex = 11;
@@ -186,7 +134,7 @@ namespace Sleave.view
             // cboAction
             // 
             this.cboAction.FormattingEnabled = true;
-            this.cboAction.Location = new System.Drawing.Point(478, 272);
+            this.cboAction.Location = new System.Drawing.Point(478, 262);
             this.cboAction.Name = "cboAction";
             this.cboAction.Size = new System.Drawing.Size(175, 21);
             this.cboAction.TabIndex = 12;
@@ -194,7 +142,7 @@ namespace Sleave.view
             // 
             // btnValid
             // 
-            this.btnValid.Location = new System.Drawing.Point(478, 305);
+            this.btnValid.Location = new System.Drawing.Point(478, 295);
             this.btnValid.Name = "btnValid";
             this.btnValid.Size = new System.Drawing.Size(75, 23);
             this.btnValid.TabIndex = 13;
@@ -204,7 +152,7 @@ namespace Sleave.view
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(578, 305);
+            this.btnCancel.Location = new System.Drawing.Point(578, 295);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 14;
@@ -212,11 +160,64 @@ namespace Sleave.view
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
+            // dgvPersonnel
+            // 
+            this.dgvPersonnel.AllowUserToAddRows = false;
+            this.dgvPersonnel.AllowUserToDeleteRows = false;
+            this.dgvPersonnel.AllowUserToResizeColumns = false;
+            this.dgvPersonnel.AllowUserToResizeRows = false;
+            dataGridViewCellStyle5.BackColor = System.Drawing.Color.WhiteSmoke;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.Black;
+            this.dgvPersonnel.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle5;
+            this.dgvPersonnel.BackgroundColor = System.Drawing.SystemColors.Control;
+            this.dgvPersonnel.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.dgvPersonnel.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.ControlDarkDark;
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.ControlDarkDark;
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvPersonnel.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle6;
+            this.dgvPersonnel.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
+            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle7.BackColor = System.Drawing.Color.LightGray;
+            dataGridViewCellStyle7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvPersonnel.DefaultCellStyle = dataGridViewCellStyle7;
+            this.dgvPersonnel.EnableHeadersVisualStyles = false;
+            this.dgvPersonnel.GridColor = System.Drawing.SystemColors.ScrollBar;
+            this.dgvPersonnel.Location = new System.Drawing.Point(12, 12);
+            this.dgvPersonnel.MultiSelect = false;
+            this.dgvPersonnel.Name = "dgvPersonnel";
+            this.dgvPersonnel.ReadOnly = true;
+            this.dgvPersonnel.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
+            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle8.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle8.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvPersonnel.RowHeadersDefaultCellStyle = dataGridViewCellStyle8;
+            this.dgvPersonnel.RowHeadersVisible = false;
+            this.dgvPersonnel.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.dgvPersonnel.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dgvPersonnel.Size = new System.Drawing.Size(751, 221);
+            this.dgvPersonnel.TabIndex = 32;
+            // 
             // FrmPersonnel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(774, 441);
+            this.Controls.Add(this.dgvPersonnel);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnValid);
             this.Controls.Add(this.cboAction);
@@ -230,7 +231,6 @@ namespace Sleave.view
             this.Controls.Add(this.txtPhone);
             this.Controls.Add(this.txtMail);
             this.Controls.Add(this.txtLastName);
-            this.Controls.Add(this.dgvPersonnel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.Name = "FrmPersonnel";
@@ -238,6 +238,7 @@ namespace Sleave.view
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Gestion du personnel";
+            this.Load += new System.EventHandler(this.FrmPersonnel_Load);
             ((System.ComponentModel.ISupportInitialize)(this.dgvPersonnel)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -245,8 +246,6 @@ namespace Sleave.view
         }
 
         #endregion
-
-        private System.Windows.Forms.DataGridView dgvPersonnel;
         private System.Windows.Forms.TextBox txtLastName;
         private System.Windows.Forms.TextBox txtMail;
         private System.Windows.Forms.TextBox txtPhone;
@@ -260,5 +259,6 @@ namespace Sleave.view
         private System.Windows.Forms.ComboBox cboAction;
         private System.Windows.Forms.Button btnValid;
         private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.DataGridView dgvPersonnel;
     }
 }

--- a/view/FrmPersonnel.cs
+++ b/view/FrmPersonnel.cs
@@ -18,6 +18,16 @@ namespace Sleave.view
     public partial class FrmPersonnel : Form
     {
         /// <summary>
+        /// Constante d'unité de largeur des champs de la grille de données
+        /// </summary>
+        private const int fieldWidthUnit = 25;
+
+        /// <summary>
+        /// Constante du nombre de ligne affichée sans barre déroulante
+        /// </summary>
+        private const int maxRows = 9;
+
+        /// <summary>
         /// Instance de controle
         /// </summary>
         Controller controller;
@@ -43,6 +53,7 @@ namespace Sleave.view
             BindDGVDepts();
             BindActions();
             DrawDGVPersonnel();
+            ResizeDGVPersonnel();
             TogglePersFields();
             ToggleButtons();
         }
@@ -131,7 +142,6 @@ namespace Sleave.view
                         Dept deptAdd = (Dept)bdgDepts.List[bdgDepts.Position];
                         Personnel persAdd = new Personnel(0, txtLastName.Text, txtFirstName.Text, txtPhone.Text, txtMail.Text, deptAdd.GetIdDept, deptAdd.GetName);
                         controller.AddPersonnel(persAdd);
-                        bdgPersonnel.MoveLast();
                     }
                     break;
                 // Supprimer
@@ -140,7 +150,6 @@ namespace Sleave.view
                     if (ConfirmChange(persDel, "Supprimer le personnel n° ", "Supprimer")){
                         controller.DeleteAllAbsences(persDel.GetIdPersonnel);
                         controller.DeletePersonnel(persDel);
-                        bdgPersonnel.MoveFirst();
                     }
                     break;
                 // Modifier
@@ -163,6 +172,8 @@ namespace Sleave.view
             }
             ResetForm();
             BindDGVPersonnel();
+            ResizeDGVPersonnel();
+            bdgPersonnel.MoveFirst();
         }
 
         /// <summary>
@@ -213,16 +224,26 @@ namespace Sleave.view
             dgvPersonnel.Columns["GetIdDept"].Visible = false;
             dgvPersonnel.Columns["GetDept"].HeaderText = "Service";
             dgvPersonnel.Columns["GetDept"].DisplayIndex = 1;
-            dgvPersonnel.Columns["GetIdPersonnel"].Width = 50;
-            dgvPersonnel.Columns["GetLastName"].Width = 125;
-            dgvPersonnel.Columns["GetFirstName"].Width = 125;
-            dgvPersonnel.Columns["GetPhone"].Width = 125;
-            dgvPersonnel.Columns["GetMail"].Width = 175;
-            dgvPersonnel.Columns["GetDept"].Width = 150;
-            if (dgvPersonnel.RowCount < 10)
+            dgvPersonnel.Columns["GetDept"].Width = fieldWidthUnit * 5;
+            dgvPersonnel.Columns["GetIdPersonnel"].Width = fieldWidthUnit * 2;
+            dgvPersonnel.Columns["GetLastName"].Width = fieldWidthUnit * 5;
+            dgvPersonnel.Columns["GetFirstName"].Width = fieldWidthUnit * 5;
+            dgvPersonnel.Columns["GetPhone"].Width = fieldWidthUnit * 5;
+            dgvPersonnel.Columns["GetMail"].Width = fieldWidthUnit * 7;
+        }
+
+        /// <summary>
+        /// Defini la taille du champs Adresse Email selon le nombre de ligne dans la grille de données
+        /// </summary>
+        private void ResizeDGVPersonnel() {
+            if (dgvPersonnel.RowCount > maxRows)
             {
-                dgvPersonnel.Width -= 17;
-                Width -= 17;
+                dgvPersonnel.Columns["GetMail"].Width = fieldWidthUnit *7;
+            }
+            else
+            {
+
+                dgvPersonnel.Columns["GetMail"].Width = fieldWidthUnit * 8;
             }
         }
 
@@ -247,6 +268,9 @@ namespace Sleave.view
             btnValid.Enabled = !btnValid.Enabled;
         }
 
+        /// <summary>
+        /// Active ou désactive les champs de sélection
+        /// </summary>
         private void ToggleSelection()
         {
             dgvPersonnel.Enabled = !dgvPersonnel.Enabled;
@@ -336,6 +360,11 @@ namespace Sleave.view
             }
             return false;
 
+
+        }
+
+        private void FrmPersonnel_Load(object sender, EventArgs e)
+        {
 
         }
     }


### PR DESCRIPTION
Affichages des absences
Une fois que l'interface de gestion du personnel est affichée et qu'un personel est selectionné, l'utlisateur choisi l'action "Afficher les absences" et valide en cliquant "valider":
- L'interface de gestion du personnel se ferme (hide)
- L'interface de gestion des absences s'ouvre et affiche les absences du personnel selectionné
- Les boutons sont désactivés
- Les champs d'informations/ de saisies sont désactivés
- L'utilisateur ne peut que selectionner une absence et/ ou choisir une action 

Si aucun personnel n'est selectionné (la grille est vide): 
- L'utilisateur est informé
- L'action est annulée
- L'interface est réinitialisée comme lors de sa création

L'utlisateur peut annuler l'affichage:
- En cliquant "Annuler" dans l'interface de gestion du personnel
- En fermant l'interface de gestion des absences
Dans les 2 cas l'interface de gestion du personnel est réinitialisée comme lors de sa création

Changement:
- Les interfaces ont été retravaillé pour mieux gérer l'esthétique des grilles de données