### PR TITLE
Cas d'utlisation n° 6 - Ajouter une absence

### DIFF
--- a/control/Controller.cs
+++ b/control/Controller.cs
@@ -126,6 +126,15 @@ namespace Sleave.control
         }
 
         /// <summary>
+        /// Demande l'ajout d'une absence à DataAccess
+        /// </summary>
+        /// <param name="absence"></param>
+        public void AddAbsence(Absence absence)
+        {
+            DataAccess.AddAbsence(absence);
+        }
+
+        /// <summary>
         /// Demande la modification d'un personnel à DataAccess
         /// </summary>
         /// <param name="persUp"></param>

--- a/dal/DataAccess.cs
+++ b/dal/DataAccess.cs
@@ -72,7 +72,7 @@ namespace Sleave.dal
         {
             List<Dept> depts = new List<Dept>();
             string req = "SELECT idservice AS idDept, nom AS dept ";
-            req += "FROM `service` ";
+            req += "FROM service ";
             req += "WHERE 1 ";
             req += "ORDER BY dept ";
             ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
@@ -99,7 +99,7 @@ namespace Sleave.dal
             req += "JOIN personnel AS p ON p.idpersonnel = a.idpersonnel ";
             req += "JOIN motif AS m ON a.idmotif = m.idmotif ";
             req += "WHERE a.idpersonnel = @idpersonnel ";
-            req += "ORDER BY dateStart desc";
+            req += "ORDER BY dateStart DESC";
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters.Add("@idpersonnel", pers.GetIdPersonnel);
             ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
@@ -120,7 +120,7 @@ namespace Sleave.dal
         public static List<Reason> GetReasons()
         {
             List<Reason> reasons = new List<Reason>();
-            string req = "SELECT idmotif AS idReason, libelle AS reason";
+            string req = "SELECT idmotif AS idReason, libelle AS reason ";
             req += "FROM motif ";
             req += "WHERE 1 ";
             req += "ORDER BY reason ";
@@ -186,6 +186,24 @@ namespace Sleave.dal
             ConnectionDataBase conn = ConnectionDataBase.GetInstance(connectionString);
             conn.ReqNoQuery(req, parameters);
         }
+
+        /// <summary>
+        /// Ajoute une absence à une personnel de la base de données
+        /// </summary>
+        /// <param name="absence"></param>
+        public static void AddAbsence(Absence absence)
+        {
+            string req = "INSERT INTO absence(dateDebut, dateFin,idpersonnel, idmotif) ";
+            req += "VALUES (@dateStart, @datEnd, @idPersonnel, @idReason);";
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("@dateStart", absence.GetDateStart.Date.ToString("yyyy-MM-dd"));
+            parameters.Add("@datEnd", absence.GetDateEnd.Date.ToString("yyyy-MM-dd"));
+            parameters.Add("@idPersonnel", absence.GetIdpersonnel);
+            parameters.Add("@idReason", absence.GetIdReason);
+            ConnectionDataBase conn = ConnectionDataBase.GetInstance(connectionString);
+            conn.ReqNoQuery(req, parameters);
+        }
+
 
         /// <summary>
         /// Efface toutes les absences d'un personnel de la base de données

--- a/model/Reason.cs
+++ b/model/Reason.cs
@@ -24,12 +24,12 @@ namespace Sleave.model
         /// <summary>
         /// Getter sur l'identifiant du motif 
         /// </summary>
-        public int GetIdmotif { get => idReason; }
+        public int GetIdReason { get => idReason; }
 
         /// <summary>
         /// Getter sur le libellé du motif
         /// </summary>
-        public string GetLibelle { get => name; }
+        public string GetName { get => name; }
 
         /// <summary>
         /// Constructeur du motif: valorise les propriétés

--- a/view/FrmAbsences.Designer.cs
+++ b/view/FrmAbsences.Designer.cs
@@ -29,10 +29,10 @@ namespace Sleave.view
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnValid = new System.Windows.Forms.Button();
             this.cboAction = new System.Windows.Forms.ComboBox();
@@ -46,9 +46,9 @@ namespace Sleave.view
             this.txtDateStart = new System.Windows.Forms.TextBox();
             this.txtDateEnd = new System.Windows.Forms.TextBox();
             this.txtLastname = new System.Windows.Forms.TextBox();
+            this.dgvAbsences = new System.Windows.Forms.DataGridView();
             this.dtpStart = new System.Windows.Forms.DateTimePicker();
             this.dtpEnd = new System.Windows.Forms.DateTimePicker();
-            this.dgvAbsences = new System.Windows.Forms.DataGridView();
             ((System.ComponentModel.ISupportInitialize)(this.dgvAbsences)).BeginInit();
             this.SuspendLayout();
             // 
@@ -60,6 +60,7 @@ namespace Sleave.view
             this.btnCancel.TabIndex = 27;
             this.btnCancel.Text = "Annuler";
             this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // btnValid
             // 
@@ -78,7 +79,7 @@ namespace Sleave.view
             this.cboAction.Name = "cboAction";
             this.cboAction.Size = new System.Drawing.Size(175, 21);
             this.cboAction.TabIndex = 25;
-            this.cboAction.SelectedIndexChanged += new System.EventHandler(this.cboAction_SelectedIndexChanged);
+            this.cboAction.SelectedIndexChanged += new System.EventHandler(this.CboAction_SelectedIndexChanged);
             // 
             // lblReason
             // 
@@ -144,7 +145,7 @@ namespace Sleave.view
             // txtDateStart
             // 
             this.txtDateStart.Enabled = false;
-            this.txtDateStart.Location = new System.Drawing.Point(480, 90);
+            this.txtDateStart.Location = new System.Drawing.Point(480, 87);
             this.txtDateStart.Name = "txtDateStart";
             this.txtDateStart.Size = new System.Drawing.Size(175, 20);
             this.txtDateStart.TabIndex = 17;
@@ -165,53 +166,37 @@ namespace Sleave.view
             this.txtLastname.Size = new System.Drawing.Size(175, 20);
             this.txtLastname.TabIndex = 15;
             // 
-            // dtpStart
-            // 
-            this.dtpStart.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.dtpStart.Location = new System.Drawing.Point(480, 90);
-            this.dtpStart.Name = "dtpStart";
-            this.dtpStart.Size = new System.Drawing.Size(175, 20);
-            this.dtpStart.TabIndex = 29;
-            // 
-            // dtpEnd
-            // 
-            this.dtpEnd.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.dtpEnd.Location = new System.Drawing.Point(480, 122);
-            this.dtpEnd.Name = "dtpEnd";
-            this.dtpEnd.Size = new System.Drawing.Size(175, 20);
-            this.dtpEnd.TabIndex = 30;
-            // 
             // dgvAbsences
             // 
             this.dgvAbsences.AllowUserToAddRows = false;
             this.dgvAbsences.AllowUserToDeleteRows = false;
             this.dgvAbsences.AllowUserToResizeColumns = false;
             this.dgvAbsences.AllowUserToResizeRows = false;
-            dataGridViewCellStyle1.BackColor = System.Drawing.Color.WhiteSmoke;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.DarkGray;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
-            this.dgvAbsences.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle17.BackColor = System.Drawing.Color.WhiteSmoke;
+            dataGridViewCellStyle17.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            dataGridViewCellStyle17.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle17.SelectionForeColor = System.Drawing.Color.Black;
+            this.dgvAbsences.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle17;
             this.dgvAbsences.BackgroundColor = System.Drawing.SystemColors.Control;
             this.dgvAbsences.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dgvAbsences.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlDarkDark;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.ControlDarkDark;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvAbsences.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle18.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle18.BackColor = System.Drawing.SystemColors.ControlDarkDark;
+            dataGridViewCellStyle18.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle18.ForeColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle18.SelectionBackColor = System.Drawing.SystemColors.ControlDarkDark;
+            dataGridViewCellStyle18.SelectionForeColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle18.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvAbsences.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle18;
             this.dgvAbsences.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.LightGray;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.DarkGray;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvAbsences.DefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle19.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle19.BackColor = System.Drawing.Color.LightGray;
+            dataGridViewCellStyle19.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle19.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle19.SelectionBackColor = System.Drawing.Color.DarkGray;
+            dataGridViewCellStyle19.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle19.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvAbsences.DefaultCellStyle = dataGridViewCellStyle19;
             this.dgvAbsences.EnableHeadersVisualStyles = false;
             this.dgvAbsences.GridColor = System.Drawing.SystemColors.ScrollBar;
             this.dgvAbsences.Location = new System.Drawing.Point(12, 12);
@@ -219,25 +204,43 @@ namespace Sleave.view
             this.dgvAbsences.Name = "dgvAbsences";
             this.dgvAbsences.ReadOnly = true;
             this.dgvAbsences.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvAbsences.RowHeadersDefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle20.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle20.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle20.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle20.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle20.SelectionForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle20.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvAbsences.RowHeadersDefaultCellStyle = dataGridViewCellStyle20;
             this.dgvAbsences.RowHeadersVisible = false;
             this.dgvAbsences.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.dgvAbsences.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.dgvAbsences.Size = new System.Drawing.Size(376, 265);
             this.dgvAbsences.TabIndex = 33;
             // 
+            // dtpStart
+            // 
+            this.dtpStart.Format = System.Windows.Forms.DateTimePickerFormat.Short;
+            this.dtpStart.Location = new System.Drawing.Point(480, 87);
+            this.dtpStart.Name = "dtpStart";
+            this.dtpStart.Size = new System.Drawing.Size(175, 20);
+            this.dtpStart.TabIndex = 34;
+            // 
+            // dtpEnd
+            // 
+            this.dtpEnd.Format = System.Windows.Forms.DateTimePickerFormat.Short;
+            this.dtpEnd.Location = new System.Drawing.Point(480, 122);
+            this.dtpEnd.Name = "dtpEnd";
+            this.dtpEnd.Size = new System.Drawing.Size(175, 20);
+            this.dtpEnd.TabIndex = 35;
+            // 
             // FrmAbsences
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(674, 301);
+            this.Controls.Add(this.txtDateStart);
+            this.Controls.Add(this.dtpStart);
             this.Controls.Add(this.dgvAbsences);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnValid);
@@ -249,11 +252,9 @@ namespace Sleave.view
             this.Controls.Add(this.lblEnd);
             this.Controls.Add(this.cboReason);
             this.Controls.Add(this.txtFirstName);
-            this.Controls.Add(this.txtDateStart);
             this.Controls.Add(this.txtDateEnd);
             this.Controls.Add(this.txtLastname);
             this.Controls.Add(this.dtpEnd);
-            this.Controls.Add(this.dtpStart);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.Name = "FrmAbsences";
@@ -282,8 +283,8 @@ namespace Sleave.view
         private System.Windows.Forms.TextBox txtDateStart;
         private System.Windows.Forms.TextBox txtDateEnd;
         private System.Windows.Forms.TextBox txtLastname;
+        private System.Windows.Forms.DataGridView dgvAbsences;
         private System.Windows.Forms.DateTimePicker dtpStart;
         private System.Windows.Forms.DateTimePicker dtpEnd;
-        private System.Windows.Forms.DataGridView dgvAbsences;
     }
 }

--- a/view/FrmConnection.Designer.cs
+++ b/view/FrmConnection.Designer.cs
@@ -62,7 +62,7 @@ namespace Sleave.view
             this.btnConnection.TabIndex = 3;
             this.btnConnection.Text = "se connecter";
             this.btnConnection.UseVisualStyleBackColor = true;
-            this.btnConnection.Click += new System.EventHandler(this.btnConnection_Click);
+            this.btnConnection.Click += new System.EventHandler(this.BtnConnection_Click);
             // 
             // txtLogin
             // 

--- a/view/FrmConnection.cs
+++ b/view/FrmConnection.cs
@@ -36,7 +36,7 @@ namespace Sleave.view
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void btnConnection_Click(object sender, EventArgs e)
+        private void BtnConnection_Click(object sender, EventArgs e)
         {
             if (!txtLogin.Text.Equals("") && !txtPwd.Text.Equals(""))
             {

--- a/view/FrmPersonnel.Designer.cs
+++ b/view/FrmPersonnel.Designer.cs
@@ -238,7 +238,6 @@ namespace Sleave.view
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Gestion du personnel";
-            this.Load += new System.EventHandler(this.FrmPersonnel_Load);
             ((System.ComponentModel.ISupportInitialize)(this.dgvPersonnel)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/view/FrmPersonnel.cs
+++ b/view/FrmPersonnel.cs
@@ -59,7 +59,7 @@ namespace Sleave.view
         }
 
         /// <summary>
-        /// Recherche l'action demandé après selection
+        /// Recherche l'action demandée après selection
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -121,7 +121,6 @@ namespace Sleave.view
             txtPhone.Enabled = false;
             txtMail.Enabled = false;
             cboDept.Enabled = false;
-            cboDept.SelectedIndex = -1;
             cboDept.Text = "";
             cboAction.Text = "Gérer le personnel";
         }
@@ -194,7 +193,6 @@ namespace Sleave.view
             List<Dept> depts = controller.GetDepts();
             bdgDepts.DataSource = depts;
             cboDept.DataSource = bdgDepts;
-            cboDept.SelectedIndex = -1;
             cboDept.Text = "";
         }
 
@@ -285,7 +283,6 @@ namespace Sleave.view
             txtFirstName.Text = "";
             txtPhone.Text = "";
             txtMail.Text = "";
-            cboDept.SelectedIndex = -1;
             cboDept.Text = "";
         }
 
@@ -320,7 +317,7 @@ namespace Sleave.view
             cboDept.Text = value;
             if (index < 0 || cboDept.SelectedIndex < 0)
             {
-                MessageBox.Show("Choisissez un service.");
+                MessageBox.Show("Choisissez un service existant.");
                 return false;
             }
             return true;
@@ -337,7 +334,6 @@ namespace Sleave.view
                 MessageBox.Show("Aucun personnel n'est selectionné.");
                 ToggleSelection();
                 ToggleButtons();
-                cboAction.SelectedIndex = -1;
                 cboAction.Text = "Gérer le personnel";
                 return false;
             }


### PR DESCRIPTION
Une fois l'interface de gestion des absences affichée, l'utilisateur choisi "Ajouter" dans la liste déroulante d'actions, rempli les champs d'informations/ de saisies et valide en cliquant "Valider".
- Si le personnel n'est pas déjà absent dans la période saisie, l'absence est ajoutée à la base de donnée.
- Si le personnel est déja absent dans cette période, l'utilisateur est alerté et l'action interrompue.

La verification de l'absence se passe en 3 étapes:
- La date de début se trouve entre la date de début  et de fin d'une absence
- La date de fin se trouve entre la date de début et de fin d'une absence
- La date de début se trouve avant une absence et la date de fin après cette même absence

Après l'ajout l'interface est réinitialisée comme lors de sa création.


L'utilisateur peut annuler l'action en cliquant sur "Annuler".
- L'interface est reinitialisée comme lors de sa création.


Changement:
Lors de la programmation, il s'est avéré qu'il est inutile de changer l'index des listes déroulantes d'actions pour pouvoir afficher un texte de liste. Cette commande a été retiré de toutes les méthodes.