### PR TITLE
Cas d'utilisation n° 7 - Supprimer une absence (3)

### DIFF
--- a/control/Controller.cs
+++ b/control/Controller.cs
@@ -126,6 +126,15 @@ namespace Sleave.control
         }
 
         /// <summary>
+        /// Demande la modification d'un personnel à DataAccess
+        /// </summary>
+        /// <param name="persUp"></param>
+        public void UpdatePersonnel(Personnel persUp)
+        {
+            DataAccess.UpdatePersonnel(persUp);
+        }
+
+        /// <summary>
         /// Demande l'ajout d'une absence à DataAccess
         /// </summary>
         /// <param name="absence"></param>
@@ -134,13 +143,9 @@ namespace Sleave.control
             DataAccess.AddAbsence(absence);
         }
 
-        /// <summary>
-        /// Demande la modification d'un personnel à DataAccess
-        /// </summary>
-        /// <param name="persUp"></param>
-        public void UpdatePersonnel(Personnel persUp)
+        internal void DelAbsence(Absence absenceDel)
         {
-            DataAccess.UpdatePersonnel(persUp);
+            DataAccess.DelAbsence(absenceDel);
         }
 
         /// <summary>

--- a/dal/DataAccess.cs
+++ b/dal/DataAccess.cs
@@ -52,7 +52,7 @@ namespace Sleave.dal
             string req = "SELECT p.idpersonnel AS idPersonnel, s.idservice AS idDept, s.nom AS dept, p.nom AS lastName, p.prenom AS firstName, p.tel AS phone, p.mail AS mail ";
             req += "FROM personnel p ";
             req += "JOIN service AS s ON (p.idservice = s.idservice) ";
-            req += "ORDER BY p.idpersonnel ";
+            req += "ORDER BY p.idpersonnel;";
             ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
             curs.ReqSelect(req, null);
             while (curs.Read())
@@ -74,7 +74,7 @@ namespace Sleave.dal
             string req = "SELECT idservice AS idDept, nom AS dept ";
             req += "FROM service ";
             req += "WHERE 1 ";
-            req += "ORDER BY dept ";
+            req += "ORDER BY dept;";
             ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
             curs.ReqSelect(req, null);
             while (curs.Read())
@@ -99,7 +99,7 @@ namespace Sleave.dal
             req += "JOIN personnel AS p ON p.idpersonnel = a.idpersonnel ";
             req += "JOIN motif AS m ON a.idmotif = m.idmotif ";
             req += "WHERE a.idpersonnel = @idpersonnel ";
-            req += "ORDER BY dateStart DESC";
+            req += "ORDER BY dateStart DESC;";
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters.Add("@idpersonnel", pers.GetIdPersonnel);
             ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
@@ -123,7 +123,7 @@ namespace Sleave.dal
             string req = "SELECT idmotif AS idReason, libelle AS reason ";
             req += "FROM motif ";
             req += "WHERE 1 ";
-            req += "ORDER BY reason ";
+            req += "ORDER BY reason;";
             ConnectionDataBase curs = ConnectionDataBase.GetInstance(connectionString);
             curs.ReqSelect(req, null);
             while (curs.Read())
@@ -204,6 +204,19 @@ namespace Sleave.dal
             conn.ReqNoQuery(req, parameters);
         }
 
+        /// <summary>
+        /// Efface l'absence d'un personnel de la base de données
+        /// </summary>
+        /// <param name="absenceDel"></param>
+        public static void DelAbsence(Absence absenceDel)
+        {
+            string req = "DELETE FROM absence ";
+            req += "WHERE DATE(dateDebut) = @dateStart;";
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("@dateStart", absenceDel.GetDateStart.Date.ToString("yyyy-MM-dd"));
+            ConnectionDataBase conn = ConnectionDataBase.GetInstance(connectionString);
+            conn.ReqNoQuery(req, parameters);
+        }
 
         /// <summary>
         /// Efface toutes les absences d'un personnel de la base de données
@@ -213,7 +226,6 @@ namespace Sleave.dal
         {
             string req = "DELETE FROM absence ";
             req += "WHERE idpersonnel = @idpersonnel;";
-
             Dictionary<string, object> parameters = new Dictionary<string, object>();
             parameters.Add("@idpersonnel", index);
             ConnectionDataBase conn = ConnectionDataBase.GetInstance(connectionString);

--- a/view/FrmAbsences.cs
+++ b/view/FrmAbsences.cs
@@ -133,15 +133,18 @@ namespace Sleave.view
                     break;
                 // Supprimer
                 case 1:
-
-                    if (ConfirmChange("Supprimer l'absence du " + txtDateStart.Text + " au " + txtDateStart.Text + " ?", "Supprimer"))
+                    if (bdgAbsences.Count > 0)
                     {
-                        Absence absenceDel = (Absence)bdgAbsences.List[bdgAbsences.Position];
-                        controller.DelAbsence(absenceDel);
-                    }
+                        if (ConfirmChange("Supprimer l'absence du " + txtDateStart.Text + " au " + txtDateStart.Text + " ?", "Supprimer"))
+                        {
+                            Absence absenceDel = (Absence)bdgAbsences.List[bdgAbsences.Position];
+                            controller.DelAbsence(absenceDel);
+                        }
+                    }   
                     break;
                 // Modifier
                 case 2:
+                    
                     break;
                 case 3:
                     break;

--- a/view/FrmAbsences.cs
+++ b/view/FrmAbsences.cs
@@ -82,25 +82,35 @@ namespace Sleave.view
         {
             ToggleSelection();
             ToggleButtons();
-            HideDtpProtection();
 
             switch (cboAction.SelectedIndex)
             {
                 // Ajouter 
                 case 0:
+                    HideDtpProtection();
                     cboReason.Enabled = true;
                     cboReason.Text = "Choissisez un motif";
                     break;
                 // Supprimer
                 case 1:
+                    if (bdgAbsences.Count > 0)
+                    {
+                        Absence absence = (Absence)bdgAbsences.List[bdgAbsences.Position];
+                        txtDateStart.Text = absence.GetDateStart.ToString("dd.MM.yyyy");
+                        txtDateEnd.Text = absence.GetDateEnd.ToString("dd.MM.yyyy");
+                        cboReason.Text = absence.GetReason;
+                    }
                     break;
                 // Modifier
                 case 2:
                     break;
-                case 3:
+                default:
+                    cboAction.Text = "Gérer les absences";
                     break;
             }
         }
+
+        
 
         /// <summary>
         /// Verifie et valide l'action demandée 
@@ -113,16 +123,22 @@ namespace Sleave.view
             {
                 // Ajouter 
                 case 0:
-                    Reason reason = (Reason)bdgReasons.List[bdgReasons.Position];
-                    Absence absence = new Absence(pers.GetIdPersonnel, pers.GetLastName, pers.GetFirstName, dtpStart.Value.Date, dtpStart.Value.Date, reason.GetIdReason, reason.GetName);
+                    Reason reasonAdd = (Reason)bdgReasons.List[bdgReasons.Position];
+                    Absence absenceAdd = new Absence(pers.GetIdPersonnel, pers.GetLastName, pers.GetFirstName, dtpStart.Value.Date, dtpStart.Value.Date, reasonAdd.GetIdReason, reasonAdd.GetName);
 
-                    if (CheckReason() && CheckDatesOfAbsence(absence))
+                    if (CheckReason() && CheckDatesOfAbsence(absenceAdd))
                     {
-                        controller.AddAbsence(absence);
+                        controller.AddAbsence(absenceAdd);
                     }
                     break;
                 // Supprimer
                 case 1:
+
+                    if (ConfirmChange("Supprimer l'absence du " + txtDateStart.Text + " au " + txtDateStart.Text + " ?", "Supprimer"))
+                    {
+                        Absence absenceDel = (Absence)bdgAbsences.List[bdgAbsences.Position];
+                        controller.DelAbsence(absenceDel);
+                    }
                     break;
                 // Modifier
                 case 2:
@@ -134,11 +150,21 @@ namespace Sleave.view
             ResetForm();
         }
 
+        /// <summary>
+        /// Vide les champs de protection des dates de l'absence
+        /// </summary>
+        private void EmptyDtpProtection()
+        {
+            txtDateStart.Text = "";
+            txtDateEnd.Text = "";
+        }
+
         private void ResetForm()
         {
             ToggleSelection();
             ToggleButtons();
             ShowDtpProtection();
+            EmptyDtpProtection();
             cboReason.Enabled = false;
             cboReason.Text = "";
             cboAction.Text = "Gérer les absences";
@@ -214,6 +240,7 @@ namespace Sleave.view
             List<Reason> reasons = controller.GetReasons();
             bdgReasons.DataSource = reasons;
             cboReason.DataSource = bdgReasons;
+            cboReason.SelectedItem = -1;
             cboReason.Text = "";
         }
 
@@ -343,6 +370,21 @@ namespace Sleave.view
                 }
             }
             return true;
+        }
+
+        /// <summary>
+        /// Demande la confirmation de pousuivre l'action 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="title"></param>
+        /// <returns>Vrai ou Faux</returns>
+        private bool ConfirmChange(string message, string title)
+        {
+            if (MessageBox.Show(message, title, MessageBoxButtons.YesNo) == DialogResult.Yes)
+            {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/view/FrmPersonnel.cs
+++ b/view/FrmPersonnel.cs
@@ -146,7 +146,7 @@ namespace Sleave.view
                 // Supprimer
                 case 1:
                     Personnel persDel = (Personnel)bdgPersonnel.List[bdgPersonnel.Position];
-                    if (ConfirmChange(persDel, "Supprimer le personnel n° ", "Supprimer")){
+                    if (ConfirmChange("Supprimer le personnel n° " + persDel.GetIdPersonnel + " : " + persDel.GetFirstName + " " + persDel.GetLastName + " ?", "Supprimer")){
                         controller.DeleteAllAbsences(persDel.GetIdPersonnel);
                         controller.DeletePersonnel(persDel);
                     }
@@ -156,7 +156,7 @@ namespace Sleave.view
                     if (CheckPersFields())
                     {
                         Personnel persMod = (Personnel)bdgPersonnel.List[bdgPersonnel.Position];
-                        if (ConfirmChange(persMod, "Modifier le personnel n° ", "Modifier"))
+                        if (ConfirmChange("Modifier le personnel n° " + persMod.GetIdPersonnel + " : " + persMod.GetFirstName + " " + persMod.GetLastName + " ?", "Modifier"))
                         {
                             Dept deptUp = (Dept)bdgDepts.List[bdgDepts.Position];
                             Personnel persUp = new Personnel(persMod.GetIdPersonnel, txtLastName.Text, txtFirstName.Text, txtPhone.Text, txtMail.Text, deptUp.GetIdDept, deptUp.GetName);
@@ -343,13 +343,12 @@ namespace Sleave.view
         /// <summary>
         /// Demande la confirmation de pousuivre l'action 
         /// </summary>
-        /// <param name="pers"></param>
         /// <param name="message"></param>
         /// <param name="title"></param>
         /// <returns>Vrai ou Faux</returns>
-        private bool ConfirmChange(Personnel pers, string message, string title)
+        private bool ConfirmChange(string message, string title)
         {
-            if (MessageBox.Show(message + pers.GetIdPersonnel + " : " + pers.GetFirstName + " " + pers.GetLastName + " ?", title, MessageBoxButtons.YesNo) == DialogResult.Yes)
+            if (MessageBox.Show(message, title, MessageBoxButtons.YesNo) == DialogResult.Yes)
             {
                 return true;
             }


### PR DESCRIPTION
(Les changements ne peuvent être tirés ?! >> Essai avec un tirage à partir GitHub)

Une fois l'interface de gestion des absences affichée, l'utlisateur selectionne une absence, choisi "Supprimer" dans la liste déroulante d'actions. L'absence est alors affichée dans le champs d'informations/ de saisies. L'utilisateur valide l'action. Il lui est demandé de confirmer la suppression.
- Si la suppression est confirmée, l'absence est effacée de la BDD. 
- Si la suppression n'est pas confirmée, l'action est interrompue et l'absence reste affichée.


L'utilisateur peut annuler l'action en cliquant sur "Annuler".
- L'interface est réinitialisée comme lors de sa création


Changements:
- Une selection de l'index est bien nécéssaire pour afficher un texte de liste. Le code est en cours de correction.

